### PR TITLE
Misc fixes

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,1 +1,0 @@
-carpentryconnect.org

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,7 @@
 ---
 title: How to Contribute
 layout: default
+permalink: /contributing/
 ---
 
 <section class="intro">
@@ -23,7 +24,7 @@ Files for pages available in the menu bar at the top of the website are availabl
 - in-person.markdown
 - online.markdown
 - case-studies.markdown
-- contributing.markdown
+- CONTRIBUTING.md
 
 
 ### Stylesheet

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,21 +28,22 @@ Files for pages available in the menu bar at the top of the website are availabl
 
 
 ### Stylesheet
-All associated styling that makes pages in this resource readable and aesthetically pleasing can be found in the [css](/css) folder.  
+
+All associated styling that makes pages in this resource readable and aesthetically pleasing can be found in the [css](https://github.com/CarpentryConnect/carpentryconnect.org/tree/master/css) folder.
 
 
 ### YAML files
 
 YAML files are a human-readable way to feed data into our website.
 
-- [_config.yml](/_config.yml) holds information about navigation settings.
+- [_config.yml](https://github.com/CarpentryConnect/carpentryconnect.org/blob/master/_config.yml) holds information about navigation settings.
 
 
 Be careful about spacing when working with YAML files. When in doubt / experiencing errors, use a linter service like [YAMLlint](http://www.yamllint.com) to validate your additions. 
 
 ### Image Files
 
-All image files are in the [img](/img) folder.
+All image files are in the [img](https://github.com/CarpentryConnect/carpentryconnect.org/tree/master/img) folder.
 
 ## Setting Up a Local Instance
 
@@ -69,10 +70,10 @@ This looks at your GEMFILE and installs all ruby gems listed in it.
 
 ### Submit an Issue
 
-We welcome any questions you may have about setting up or contributing to this website repository in the [issues](/issues) section of this repository.
+We welcome any questions you may have about setting up or contributing to this website repository in the [issues](https://github.com/CarpentryConnect/carpentryconnect.org/issues) section of this repository.
 
 ### Email us
 
-Where email is preferred, you can reach out to us on [community@carpentries.org](community@carpentries.org).
+Where email is preferred, you can reach out to us on [community@carpentries.org](mailto:community@carpentries.org).
 
 

--- a/_config.yml
+++ b/_config.yml
@@ -1,15 +1,10 @@
 navigation:
 - text: In-Person Events
-  relative_url: in-person
-  url: /in-person.html
+  url: /in-person/
 - text: Online Events
-  relative_url: online
-  url: /online.html
+  url: /online/
 - text: Case Studies
-  relative_url: case-studies
-  url: /case-studies.html
+  url: /case-studies/
 - text: Contribute
-  relative_url: contributing
-  url: /contributing.html
+  url: /contributing/
 markdown: kramdown
-

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -1,8 +1,5 @@
-{% for link in site.navigation %}
-	{% if page.url == link.url %}
-		{% assign bodyclass = link.relative_url %}
-	{% endif %}
-{% endfor %}
+{% assign bodyclass = page.permalink | remove: "/" %}
+
 <!DOCTYPE html>
 <!--[if lt IE 9]><html class="lt-ie9" lang="en"><![endif]-->
 <!--[if gte IE 9]><!-->
@@ -27,7 +24,7 @@
 		<script src="https://use.typekit.net/uzj8mcd.js"></script>
 		<script>try{Typekit.load({ async: true });}catch(e){}</script>
 	</head>
-	<body class="{{ bodyclass }}">
+<body class="{{ bodyclass }}">
 		<div class="header_container" id="top">
 			<header class="group container primary">
 				<div class="branding">
@@ -44,7 +41,7 @@
 								{% assign class = '' %}
 							{% endif %}
 							<li class="{{ class }}">
-							<a href="{{ link.relative_url }}">{{ link.text }}</a>
+							<a href="{{ link.url }}">{{ link.text }}</a>
 							</li>
 						{% endfor %}
 					</ul>

--- a/case-studies.markdown
+++ b/case-studies.markdown
@@ -1,6 +1,7 @@
 ---
 title: Case Studies
 layout: default
+permalink: /case-studies/
 ---
 
 <section class="intro">

--- a/css/styles.css
+++ b/css/styles.css
@@ -770,7 +770,7 @@ body.case-studies .heading h1:before {
     background-image: url(/img/watermark_carpentryconnect.png);
     left: -100px;
 }
-body.contribute .heading h1:before {
+body.contributing .heading h1:before {
     background-image: url(/img/watermark_carpentryconnect.png);
     left: -100px;
 }

--- a/in-person.markdown
+++ b/in-person.markdown
@@ -1,6 +1,7 @@
 ---
 title: In-Person CarpentryConnects
 layout: default
+permalink: /in-person/
 ---
 
 <style type="text/css">

--- a/online.markdown
+++ b/online.markdown
@@ -1,6 +1,7 @@
 ---
 title: Online CarpentryConnects
 layout: default
+permalink: /online/
 ---
 <style type="text/css">
 figure img { border: 1px solid #999999;}
@@ -21,7 +22,7 @@ figure figcaption { font-style: italic; font-size: 0.85em; text-align: center;}
 }
 .reading, .templates { 
 	margin: 0 3em 0 3em;
-	background-color: #F4ECE6;  
+	background-color: #F4ECE6;
 	padding: 0.25em 1em 0.25em 1em;
 	color: #41322f;				
 }


### PR DESCRIPTION
@serahrono here are a few suggestions to the carpentryconnect website.

As it's currently written, the url will be in the format `/online` for instance and this is not compatible with hosting on AWS S3 (which is required to allow for multiple sub-domains and provide flexibility with the event organizers for their hosting needs). The changes proposed here will make the url in the `/online/` format which will work with AWS S3 hosting.

I also fixed a couple of URLs and standardized the file extensions.

Let me know if you have any questions.