### PR TITLE
remove google analytics

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -93,13 +93,5 @@
 		<script src="js/template.js"></script>
 		<script src="//cdnjs.cloudflare.com/ajax/libs/highlight.js/8.5/highlight.min.js"></script>
 		<script>hljs.initHighlightingOnLoad();</script>
-		<script>
-			(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-			(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-			m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-			})(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-			ga('create', 'UA-6769990-6', 'imarc.net');
-			ga('send', 'pageview');
-		</script>
 	</body>
 </html>


### PR DESCRIPTION
With GDPR, I'd prefer we don't use Google Analytics without adding a way for users to confirm that they are OK with it (it's coming for our other websites), and it looks like this is actually not using a tracking code that belongs to us.