### PR TITLE
Update ruby action repo

### DIFF
--- a/.github/workflows/build-deploy.yml
+++ b/.github/workflows/build-deploy.yml
@@ -12,7 +12,7 @@ jobs:
     - name: checkout
       uses: actions/checkout@master
     - name: Install Ruby
-      uses: actions/setup-ruby@v1
+      uses: ruby/setup-ruby@v1
       with:
         ruby-version: 2.5
     - name: Install Jekyll and dependencies


### PR DESCRIPTION
actions/setup-ruby is no longer maintained. Update build-deploy.yml to point to the successor, ruby/setup-ruby